### PR TITLE
[INJI-597] customize npm sonar analysis

### DIFF
--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -21,6 +21,22 @@ on:
         required: false
         type: string
         default: 'NG'
+      SONAR_SOURCES:
+        required: false
+        type: string
+        default: 'src'
+      SONAR_TESTS:
+        required: false
+        type: string
+        default: 'src'
+      SONAR_TEST_INCLUSIONS:
+        required: false
+        type: string
+        default: '**/*.spec.ts'
+      SONAR_EXCLUSIONS:
+        required: false
+        type: string
+        default: '**/node_modules/**'
     secrets:
       SONAR_TOKEN:
         required: true
@@ -87,27 +103,17 @@ jobs:
   
         cd "./${{inputs.SERVICE_LOCATION}}"
         
-        repo_name="${{ github.event.repository.name }}"
-        if [[ "$repo_name" == "inji" ]]; then
-          echo "
+        echo "
           sonar.host.url=${{ inputs.SONAR_URL }}
           sonar.login=${{ secrets.SONAR_TOKEN }}
           sonar.projectKey=${{ inputs.PROJECT_KEY }}
           sonar.organization=${{ secrets.ORG_KEY }}
           sonar.sourceEncoding=UTF-8
+          sonar.sources=${{ inputs.SONAR_SOURCES }}
+          sonar.exclusions=${{ inputs.SONAR_EXCLUSIONS }}
+          sonar.tests=${{ inputs.SONAR_TESTS }}
+          sonar.test.inclusions=${{ inputs.SONAR_TEST_INCLUSIONS }}
           sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
-        else
-          echo "sonar.host.url=${{ inputs.SONAR_URL }}
-                sonar.login=${{ secrets.SONAR_TOKEN }}
-                sonar.projectKey=${{ inputs.PROJECT_KEY }}
-                sonar.organization=${{ secrets.ORG_KEY }}
-                sonar.sourceEncoding=UTF-8
-                sonar.sources=src
-                sonar.exclusions=**/node_modules/**
-                sonar.tests=src
-                sonar.test.inclusions=**/*.spec.ts
-                sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
-        fi
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         ORG_KEY: ${{ secrets.ORG_KEY }}

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -69,48 +69,48 @@ jobs:
         # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
         echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
-  
-  - name: setup sonar properties
-    run: |
-      if [[ -z $SONAR_TOKEN ]]; then
-        echo "\$SONAR_TOKEN environmental variable not set; EXITING;";
-        exit 1;
-      fi
-      if [[ -z $ORG_KEY ]]; then
-        echo "\$ORG_KEY environmental variable not set; EXITING;";
-        exit 1;
-      fi
-      if [[ -z $SONAR_URL ]]; then
-        echo "\$SONAR_URL environmental variable not set; EXITING;";
-        exit 1;
-      fi
 
-      cd "./${{inputs.SERVICE_LOCATION}}"
-      
-      if [[ ${{ github.event.repository.name }}="inji"]]; then
-        echo "
-        sonar.host.url=${{ inputs.SONAR_URL }}
-        sonar.login=${{ secrets.SONAR_TOKEN }}
-        sonar.projectKey=${{ inputs.PROJECT_KEY }}
-        sonar.organization=${{ secrets.ORG_KEY }}
-        sonar.sourceEncoding=UTF-8
-        sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
-      else
-        echo "sonar.host.url=${{ inputs.SONAR_URL }}
-              sonar.login=${{ secrets.SONAR_TOKEN }}
-              sonar.projectKey=${{ inputs.PROJECT_KEY }}
-              sonar.organization=${{ secrets.ORG_KEY }}
-              sonar.sourceEncoding=UTF-8
-              sonar.sources=src
-              sonar.exclusions=**/node_modules/**
-              sonar.tests=src
-              sonar.test.inclusions=**/*.spec.ts
-              sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
-      fi
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      ORG_KEY: ${{ secrets.ORG_KEY }}
-      SONAR_URL: ${{ inputs.SONAR_URL }}    
+    - name: setup sonar properties
+      run: |
+        if [[ -z $SONAR_TOKEN ]]; then
+          echo "\$SONAR_TOKEN environmental variable not set; EXITING;";
+          exit 1;
+        fi
+        if [[ -z $ORG_KEY ]]; then
+          echo "\$ORG_KEY environmental variable not set; EXITING;";
+          exit 1;
+        fi
+        if [[ -z $SONAR_URL ]]; then
+          echo "\$SONAR_URL environmental variable not set; EXITING;";
+          exit 1;
+        fi
+  
+        cd "./${{inputs.SERVICE_LOCATION}}"
+        
+        if [[ ${{ github.event.repository.name }}="inji"]]; then
+          echo "
+          sonar.host.url=${{ inputs.SONAR_URL }}
+          sonar.login=${{ secrets.SONAR_TOKEN }}
+          sonar.projectKey=${{ inputs.PROJECT_KEY }}
+          sonar.organization=${{ secrets.ORG_KEY }}
+          sonar.sourceEncoding=UTF-8
+          sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
+        else
+          echo "sonar.host.url=${{ inputs.SONAR_URL }}
+                sonar.login=${{ secrets.SONAR_TOKEN }}
+                sonar.projectKey=${{ inputs.PROJECT_KEY }}
+                sonar.organization=${{ secrets.ORG_KEY }}
+                sonar.sourceEncoding=UTF-8
+                sonar.sources=src
+                sonar.exclusions=**/node_modules/**
+                sonar.tests=src
+                sonar.test.inclusions=**/*.spec.ts
+                sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
+        fi
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        ORG_KEY: ${{ secrets.ORG_KEY }}
+        SONAR_URL: ${{ inputs.SONAR_URL }}
 
     - name: run sonar analysis
       run: |

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -69,10 +69,33 @@ jobs:
         # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
         echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
+  
+  - name: setup sonar properties
+    run: |
+      if [[ -z $SONAR_TOKEN ]]; then
+        echo "\$SONAR_TOKEN environmental variable not set; EXITING;";
+        exit 1;
+      fi
+      if [[ -z $ORG_KEY ]]; then
+        echo "\$ORG_KEY environmental variable not set; EXITING;";
+        exit 1;
+      fi
+      if [[ -z $SONAR_URL ]]; then
+        echo "\$SONAR_URL environmental variable not set; EXITING;";
+        exit 1;
+      fi
 
-    - name: run sonar analysis
-      run: |
-        cd "./${{inputs.SERVICE_LOCATION}}"
+      cd "./${{inputs.SERVICE_LOCATION}}"
+      
+      if [[ ${{ github.event.repository.name }}="inji"]]; then
+        echo "
+        sonar.host.url=${{ inputs.SONAR_URL }}
+        sonar.login=${{ secrets.SONAR_TOKEN }}
+        sonar.projectKey=${{ inputs.PROJECT_KEY }}
+        sonar.organization=${{ secrets.ORG_KEY }}
+        sonar.sourceEncoding=UTF-8
+        sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
+      else
         echo "sonar.host.url=${{ inputs.SONAR_URL }}
               sonar.login=${{ secrets.SONAR_TOKEN }}
               sonar.projectKey=${{ inputs.PROJECT_KEY }}
@@ -83,10 +106,18 @@ jobs:
               sonar.tests=src
               sonar.test.inclusions=**/*.spec.ts
               sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
+      fi
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      ORG_KEY: ${{ secrets.ORG_KEY }}
+      SONAR_URL: ${{ inputs.SONAR_URL }}    
+
+    - name: run sonar analysis
+      run: |
+        cd "./${{inputs.SERVICE_LOCATION}}"     
         npm install sonar-scanner && npm run sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - uses: 8398a7/action-slack@v3
       with:

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -6,6 +6,9 @@ on:
       SERVICE_LOCATION:
         required: true
         type: string
+      NODE_VERSION:
+        default: '14'
+        type: string
       SONAR_URL:
         required: false
         type: string
@@ -31,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: ${{ inputs.NODE_VERSION }}
     - name: Cache npm dependencies
       uses: actions/cache@v2
       with:
@@ -50,7 +53,7 @@ jobs:
         restore-keys: ${{ runner.os }}-sonar-
 
     - name: npm install
-      run: cd ${{ inputs.SERVICE_LOCATION }} && npm install --ignore-scripts
+      run: cd ${{ inputs.SERVICE_LOCATION }} && npm install
 
     - name: NPM Build for NG
       if: ${{ inputs.NPM_BUILD_TYPE == 'NG' }}

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -87,7 +87,8 @@ jobs:
   
         cd "./${{inputs.SERVICE_LOCATION}}"
         
-        if [[ ${{ github.event.repository.name }}="inji"]]; then
+        repo_name="${{ github.event.repository.name }}"
+        if [[ "$repo_name" == "inji" ]]; then
           echo "
           sonar.host.url=${{ inputs.SONAR_URL }}
           sonar.login=${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -45,6 +45,10 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+env:
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  ORG_KEY: ${{ secrets.ORG_KEY }}
+
 jobs:
   npm-sonar-analysis:
     runs-on: ubuntu-latest
@@ -105,9 +109,7 @@ jobs:
         
         echo "
           sonar.host.url=${{ inputs.SONAR_URL }}
-          sonar.login=${{ secrets.SONAR_TOKEN }}
           sonar.projectKey=${{ inputs.PROJECT_KEY }}
-          sonar.organization=${{ secrets.ORG_KEY }}
           sonar.sourceEncoding=UTF-8
           sonar.sources=${{ inputs.SONAR_SOURCES }}
           sonar.exclusions=${{ inputs.SONAR_EXCLUSIONS }}
@@ -115,14 +117,12 @@ jobs:
           sonar.test.inclusions=${{ inputs.SONAR_TEST_INCLUSIONS }}
           sonar.typescript.lcov.reportPaths=coverage/lcov.info" >> sonar-project.properties
       env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        ORG_KEY: ${{ secrets.ORG_KEY }}
         SONAR_URL: ${{ inputs.SONAR_URL }}
 
     - name: run sonar analysis
       run: |
         cd "./${{inputs.SERVICE_LOCATION}}"     
-        npm install sonar-scanner && npm run sonar
+        npm install sonar-scanner && npm run sonar -- -Dsonar.login=${{ env.SONAR_TOKEN }} -Dsonar.organization=${{ env.ORG_KEY }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Customizations include
1. Node version as INJI required 18 node version
2. remove ignore-scripts in npm installation as INJI requires post install scripts to build successfully
3. sonar-properties as INJI has its exclusions already defined in its repo