### PR TITLE
[INJIMOB-2712] remove react-native/android specific steps from gradle sonar analysis

### DIFF
--- a/.github/workflows/gradlew-sonar-analysis.yml
+++ b/.github/workflows/gradlew-sonar-analysis.yml
@@ -6,10 +6,6 @@ on:
         description: 'SERVICE LOCATION'
         required: true
         type: string
-      ANDROID_LOCATION:
-        description: 'ANDROID LOCATION'
-        required: true
-        type: string
       SONAR_URL:
         required: false
         type: string
@@ -36,7 +32,6 @@ on:
         required: true
 
 env:
-  ANDROID_HOME: '/opt/android-sdk/'
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
@@ -51,10 +46,6 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - uses: actions/setup-node@v3.7.0
-        with:
-          node-version: '16'
-
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -64,14 +55,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle-
 
-      - name: Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: '~/.npm'
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:
@@ -79,11 +62,8 @@ jobs:
           key: ${{ runner.os }}-sonar-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-sonar-
 
-      - name: NPM Install Dependencies
-        run: cd ${{ inputs.SERVICE_LOCATION }} && npm install
-
       - name: Check if Environmental variables set for sonar
-        run: | 
+        run: |
           if [[ -z $SONAR_TOKEN ]]; then
             echo "\$SONAR_TOKEN environmental variable not set; EXITING;";
             exit 1;
@@ -99,15 +79,15 @@ jobs:
 
       - name: Analysis with Sonarcloud
         run: |
-          cd ${{ inputs.SERVICE_LOCATION }}/${{ inputs.ANDROID_LOCATION }}
+          cd ${{ inputs.SERVICE_LOCATION }}
           sed -i -e 's/\r$//' ./gradlew
           chmod +x ./gradlew
           ./gradlew build sonarqube -Dsonar.organization=${{ env.SONAR_ORGANIZATION }} -Dsonar.projectKey=${{ inputs.PROJECT_KEY }} -Dsonar.projectName=${{ inputs.PROJECT_NAME }} -Dsonar.host.url=${{ inputs.SONAR_URL }} --info --warning-mode all ${{ inputs.SONAR_ARGS }}
 
-      #- uses: 8398a7/action-slack@v3
-      #  with:
-      #    status: ${{ job.status }}
-      #    fields: repo,message,author,commit,workflow,job # selectable (default: repo,message)
-      #  env:
-      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-      #  if: "${{ github.event_name != 'pull_request' && failure() }}" # Pick up events even if the job fails or is canceled.
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,author,commit,workflow,job # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: "${{ github.event_name != 'pull_request' && failure() }}" # Pick up events even if the job fails or is canceled.

--- a/docs/gradlew-sonar-analysis-readme.md
+++ b/docs/gradlew-sonar-analysis-readme.md
@@ -11,7 +11,6 @@ This workflow is designed to perform the following tasks:
 
 This workflow accepts the following inputs:
 - `SERVICE_LOCATION`: The location of the service or project.
-- `ANDROID_LOCATION`: The location of the Android project within the service.
 - `SONAR_URL`: (Optional) The URL of the Sonar server (default: https://sonarcloud.io).
 - `PROJECT_KEY`: (Optional) The key of the Sonar project (default: "mosip_${{ github.event.repository.name }}").
 - `PROJECT_NAME`: (Optional) The name of the Sonar project (default: "${{ github.event.repository.name }").
@@ -26,9 +25,9 @@ This workflow requires the following secrets to be set in your GitHub repository
 
 ## Example Usage
 
-Here is an example workflow that uses the `Sonar Analysis via Gradlew` workflow:
+Here is an example workflow that uses the `Sonar Analysis via Gradle` workflow:
 ```yaml
-name: Gradlew sonar-analysis
+name: Gradle sonar-analysis
 on:
   release:
     types: [published]
@@ -39,7 +38,7 @@ on:
       message:
         description: 'Message for manually triggering'
         required: false
-        default: 'Triggered for Updates'
+        default: 'Triggered for Sonar analysis'
         type: string
   push:
     branches:
@@ -53,8 +52,7 @@ jobs:
     needs: <app-build-job-name>
     uses: mosip/kattu/.github/workflows/gradlew-sonar-analysis.yml@master
     with:
-      SERVICE_LOCATION: 'mosip-sbi-capacitor'
-      ANDROID_LOCATION: 'android'
+      SERVICE_LOCATION: '<project-path>'
       SONAR_URL: 'https://sonarcloud.io'
       PROJECT_KEY: "mosip_${{ github.event.repository.name }}"
       PROJECT_NAME: "${{ github.event.repository.name }}"
@@ -63,3 +61,14 @@ jobs:
       SONAR_ORGANIZATION: ${{ secrets.ORG_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 ```
+
+## Pre-requisites
+
+- Install sonarqube plugin in the project
+
+```kotlin
+plugins {
+    id("org.sonarqube") version "<version>"
+}
+```
+


### PR DESCRIPTION
- The need for this modification is due to integrating non-android gradle project
- Modified the workflow to hold non-android specifics which can be applied to any gradle project
- This workflow was created focussing inji-wallet (react native app - android) & it is not consumed by inji-wallet right now so will not be causing any effect
- Testing is done. Related workflow which ran with the changes - https://github.com/mosip/vc-verifier/actions/runs/12908503571/job/35994282461
