### PR TITLE
[INJIMOB-0.18.x]: update brew to latest version in ios-publish workflow

### DIFF
--- a/.github/workflows/ios-publish.yml
+++ b/.github/workflows/ios-publish.yml
@@ -155,6 +155,7 @@ jobs:
       
       - name: Update Fastlane to Latest Version
         run: |
+          brew update
           brew install fastlane
 
       - name: Deploy iOS Beta to TestFlight


### PR DESCRIPTION
Updated the ios-publish workflow to run brew update before installing Fastlane to ensure the latest version is used. This avoids version mismatches between local and CI environments, where GitHub-hosted runners may install a cached older version of Fastlane unless Homebrew is updated explicitly.

Example of mismatch:

Local install: 2.228.0
GitHub CI install (without update): 2.227.2