### PR TITLE
[INJIMOB-3456] use macos-14 for sonar swift-sonar-analysis

### DIFF
--- a/.github/workflows/swift-sonar-analysis.yml
+++ b/.github/workflows/swift-sonar-analysis.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   sonar-analysis:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Summary

This PR updates our GitHub Actions workflows to explicitly pin the runner to macos-14 instead of using macos-latest. We encountered failures when relying on macos-latest, as it recently began pointing to macOS 15 (Sequoia), introducing incompatibilities with our sonar analysis setup.

Why This Change?

macos-latest is migrating to macOS 15
GitHub Actions has started switching the macos-latest label to macOS 15, with rollout beginning August 4, 2025 and finishing by September 1, 2025.
🔗 [GitHub Changelog](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/?utm_source=chatgpt.com)

🔗 [Runner Images Issue](https://github.com/actions/runner-images/issues/11486?utm_source=chatgpt.com)

macOS 15 runners are already available
GitHub made macOS 15 (Sequoia) generally available on April 10, 2025, so workflows can target macos-15 explicitly.
🔗 [GitHub Changelog](https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/?utm_source=chatgpt.com)

Gradual migration can break workflows
GitHub updates -latest labels gradually, which may unexpectedly break pipelines depending on older OS configurations.
🔗 [Runner Images Repo](https://github.com/actions/runner-images?utm_source=chatgpt.com)

By pinning to macos-14, we ensure stability until we’re ready to migrate to macOS 15 intentionally.

What’s Changed in This PR

Updated workflow job from:

```
runs-on: macos-latest
```

…to:

```
runs-on: macos-14
```

Next Steps

Validate compatibility with macOS 15 (Xcode/tooling/simulator support).

Once confirmed, migrate workflows to macos-15 explicitly.

Monitor upcoming GitHub changes to default Xcode versions on macOS 15.
🔗 [Issue Ref](https://github.com/actions/runner-images/issues/12520?utm_source=chatgpt.com)