### PR TITLE
[INJIMOB-3794] refactor: update test_executable finding logic

### DIFF
--- a/.github/workflows/swift-sonar-analysis.yml
+++ b/.github/workflows/swift-sonar-analysis.yml
@@ -72,19 +72,23 @@ jobs:
           # Check if Tests directory exists and is not empty
           if [ -d "Tests" ] && [ "$(ls -A Tests 2>/dev/null)" ]; then
                 
+              DERIVED_DATA='.build/DerivedData'
               # Run tests with xcodebuild for iOS simulator
               xcodebuild test \
                   -scheme "${{ inputs.TEST_SCHEME }}" \
                   -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15' \
                   -enableCodeCoverage YES \
-                  -derivedDataPath .build/DerivedData || true
+                  -derivedDataPath $DERIVED_DATA || true
 
               # Find test bundle and executable
-              TEST_BUNDLE=$(find .build/DerivedData -type d -name "*.xctest" | head -n 1)
+              TEST_BUNDLE=$(find $DERIVED_DATA -type d -name "*.xctest" | head -n 1)
               
               if [ -n "$TEST_BUNDLE" ]; then
-                TEST_EXECUTABLE=$(find "$TEST_BUNDLE" -type f -perm -111 | head -n 1)
-                COVERAGE_PATH=$(find .build/DerivedData -name "Coverage.profdata" | head -n 1)
+                TEST_EXECUTABLE=$(find "$DERIVED_DATA/Build/Products" \
+                  -name "${{ inputs.TEST_SCHEME }}*.xctest" \
+                  -path "*/Debug-*" | head -n 1)
+                TEST_EXECUTABLE="$TEST_EXECUTABLE/$(basename "$TEST_EXECUTABLE" .xctest)"
+                COVERAGE_PATH=$(find $DERIVED_DATA -name "Coverage.profdata" | head -n 1)
 
                 if [ -n "$TEST_EXECUTABLE" ] && [ -n "$COVERAGE_PATH" ]; then
                   # Generate coverage report in text format


### PR DESCRIPTION
- Previous logic sometimes finds framework's test executable as its test executable which results in 0 test coverage
- To avoid this issue of flakiness, test executable finding logic has been updated to find the library's scheme tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build configuration to use a centralized derived-data path variable.
  * Made test and coverage discovery in CI more reliable by using the centralized path, reducing hardcoded path issues and improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->