### PR TITLE
chore: upgrade iOS build to Xcode 26 on macos-15 runner

### DIFF
--- a/.github/workflows/ios-publish.yml
+++ b/.github/workflows/ios-publish.yml
@@ -107,13 +107,13 @@ on:
 jobs:
   build_ios:
     name: Deploying to Testflight
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
       
       - name: Confirm Xcode version
         run: xcodebuild -version
@@ -122,11 +122,6 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
       
-      - name: Set up Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: '5.10.0'
-
       - name: Cache npm dependencies
         uses: actions/cache@v4
         with:
@@ -138,7 +133,7 @@ jobs:
       - name: Install CocoaPods
         run: |
           gem uninstall cocoapods -a -x
-          gem install cocoapods -v 1.15.2 --force
+          gem install cocoapods -v 1.16.2 --force
 
       - name: Install npm dependencies
         run: |


### PR DESCRIPTION
## Changes

- Update runner from `macos-14` to `macos-15`
- Switch from Xcode 16.2 to Xcode 26.0
- Remove Swift 5.10 setup step (Xcode 26 bundles Swift 6.x natively)
- Update CocoaPods from 1.15.2 to 1.16.2 for Xcode 26 compatibility

## Why

Apple requires Xcode 26+ for App Store / TestFlight publishing. The `macos-15` runner image includes Xcode 26.0 at `/Applications/Xcode_26.0.app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build infrastructure and dependencies, including compiler and package manager versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/kattu/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->