### PR TITLE
chore: upgrade ios-build.yml to Xcode 26 on macos-15 runner

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -25,18 +25,20 @@ on:
 jobs:
   build_ios:
     name: Building the IPA
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v3.1.0
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+
+      - name: Confirm Xcode version
+        run: xcodebuild -version
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.NODE_VERSION }}
-
-      - name: Set up Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: '5.10.0'
 
       - name: Cache npm dependencies
         uses: actions/cache@v4
@@ -49,7 +51,7 @@ jobs:
       - name: Install CocoaPods
         run: |
           gem uninstall cocoapods -a -x
-          gem install cocoapods -v 1.15.2 --force
+          gem install cocoapods -v 1.16.2 --force
 
       - name: Install npm dependencies
         run: |


### PR DESCRIPTION
Companion to #325 (ios-publish.yml). This updates the **ios-build.yml** workflow used by push-trigger CI builds.

## Changes
- Runner: `macos-14` → `macos-15`
- Added Xcode 26.0 selection step
- Removed `setup-swift@v2` (Xcode 26 bundles Swift 6.x)
- CocoaPods: `1.15.2` → `1.16.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build environment to use macOS 15 and Xcode 26
  * Updated CocoaPods to version 1.16.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/kattu/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->