### PR TITLE
ci: migrate GPG key handling to crazy-max/ghaction-import-gpg@v6

### DIFF
--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV          
 
       - name: Set up JDK
         uses: actions/setup-java@v2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           echo "${{ toJSON(inputs) }}"
           
           # Parse platforms into an array

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -18,6 +18,8 @@ on:
         required: true
       GPG_SECRET:
         required: true
+      GPG_PRIVATE_KEY:
+        required: true
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -46,16 +48,12 @@ jobs:
       run: |
         # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV  
 
-    - name: Setup branch and GPG public key
-      run: |
-        # Strip git ref prefix from version
-        echo ${{ env.BRANCH_NAME }}
-        echo ${{ env.GPG_TTY }}
-        sudo apt-get --yes install gnupg2
-        gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-        gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_SECRET }}
 
     - name: Install xmlstartlet and xmllint
       run: |

--- a/.github/workflows/maven-publish-android.yml
+++ b/.github/workflows/maven-publish-android.yml
@@ -23,6 +23,8 @@ on:
         required: true
       GPG_SECRET:
         required: true
+      GPG_PRIVATE_KEY:
+        required: true
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -79,16 +81,12 @@ jobs:
         run: |
           # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
-      - name: Setup branch and GPG public key
-        run: |
-          # Strip git ref prefix from version
-          echo ${{ env.BRANCH_NAME }}
-          echo ${{ env.GPG_TTY }}
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_SECRET }}
 
       - name: Install xmlstartlet and xmllint
         run: |

--- a/.github/workflows/maven-publish-to-nexus.yml
+++ b/.github/workflows/maven-publish-to-nexus.yml
@@ -17,6 +17,8 @@ on:
         required: true
       GPG_SECRET:
         required: true
+      GPG_PRIVATE_KEY:
+        required: true
       SLACK_WEBHOOK_URL:
         required: false
 
@@ -46,16 +48,12 @@ jobs:
       run: |
         # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
-    - name: Setup branch and GPG public key
-      run: |
-        # Strip git ref prefix from version
-        echo ${{ env.BRANCH_NAME }}
-        echo ${{ env.GPG_TTY }}
-        sudo apt-get --yes install gnupg2
-        gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-        gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_SECRET }}
 
     - name: Setup the settings file for ossrh server
       run: echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USER}}</username><password>${{secrets.OSSRH_SECRET}}</password></server></servers><profiles><profile><id>ossrh</id><activation><activeByDefault>true</activeByDefault></activation><properties><gpg.executable>gpg2</gpg.executable><gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase></properties></profile><profile><id>allow-snapshots</id><activation><activeByDefault>true</activeByDefault></activation><repositories><repository><id>snapshots-repo</id><url>https://central.sonatype.com/repository/maven-snapshots</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>releases-repo</id><url>https://central.sonatype.com/api/v1/publisher</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository><repository><id>danubetech-maven-public</id><url>https://repo.danubetech.com/repository/maven-public/</url></repository></repositories></profile><profile><id>sonar</id><properties><sonar.sources>.</sonar.sources><sonar.host.url>https://sonarcloud.io</sonar.host.url></properties><activation><activeByDefault>false</activeByDefault></activation></profile></profiles></settings>" > $GITHUB_WORKSPACE/settings.xml
@@ -68,7 +66,6 @@ jobs:
         cd ${{ inputs.SERVICE_LOCATION }} && mvn -DskipTests -U -B deploy -Dmaven.wagon.http.retryHandler.count=2 -DaltDeploymentRepository=ossrh::default::${{ secrets.OSSRH_URL }} -s $GITHUB_WORKSPACE/settings.xml -f pom.xml
       env:
         GITHUB_TOKEN: ${{secrets.OSSRH_TOKEN}}
-        GPG_TTY: $(tty)
 
     # - uses: 8398a7/action-slack@v3
     #   with:

--- a/.github/workflows/maven-sonar-analysis-new.yml
+++ b/.github/workflows/maven-sonar-analysis-new.yml
@@ -25,8 +25,6 @@ on:
         required: true
       OSSRH_TOKEN:
         required: true
-      GPG_SECRET:
-        required: true
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -55,17 +53,7 @@ jobs:
         run: |
           # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           echo "SONAR URL : ${{ inputs.SONAR_URL }}"
-
-      - name: Setup branch and GPG public key
-        run: |
-          # Strip git ref prefix from version
-          echo ${{ env.BRANCH_NAME }}
-          echo ${{ env.GPG_TTY }}
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
 
       - name: Setup the settings file for ossrh server
         run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://oss.sonatype.org/content/repositories/snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-sonar-analysis.yml
+++ b/.github/workflows/maven-sonar-analysis.yml
@@ -25,8 +25,6 @@ on:
         required: true
       OSSRH_TOKEN:
         required: true
-      GPG_SECRET:
-        required: true
       SLACK_WEBHOOK_URL:
         required: true
 
@@ -55,17 +53,7 @@ jobs:
         run: |
           # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           echo "SONAR URL : ${{ inputs.SONAR_URL }}"
-
-      - name: Setup branch and GPG public key
-        run: |
-          # Strip git ref prefix from version
-          echo ${{ env.BRANCH_NAME }}
-          echo ${{ env.GPG_TTY }}
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
 
       - name: Setup the settings file for ossrh server
         run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://oss.sonatype.org/content/repositories/snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -99,7 +99,6 @@ jobs:
       run: |
         # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
     - name: setup sonar properties
       run: |

--- a/.github/workflows/release-changes.yml
+++ b/.github/workflows/release-changes.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
       - name: Install xmlstartlet and xmllint
         run: |


### PR DESCRIPTION
Replace committed .github/keys GPG file imports and manual gpg2 CLI calls with the crazy-max/ghaction-import-gpg@v6 action driven by the GPG_PRIVATE_KEY repository secret in maven-build, maven-publish-to-nexus, and maven-publish-android workflows. Also removes the stale inline GPG_TTY: $(tty) env var from the maven-publish-to-nexus publish step.

For maven-sonar-analysis and maven-sonar-analysis-new, which do not sign artifacts, remove the GPG import step and GPG_SECRET secret entirely rather than migrating to the action.

Remove the leftover `echo "GPG_TTY=$(tty)"` lines from dev-check, docker-build, npm-sonar-analysis, and release-changes workflows, which never used GPG signing but had accumulated the env export.