### PR TITLE
ci: replace crazy-max GPG action with direct import and add simplify4u pgpverify check

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,41 +26,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [ 'java', 'javascript' ]
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Set up JDK 21
+      if: matrix.language == 'java'
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
+      with:
+        distribution: temurin
+        java-version: '21'
+
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        queries: security-extended
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      uses: github/codeql-action/autobuild@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -53,10 +53,8 @@ jobs:
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
 
     - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v6
-      with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_SECRET }}
+      run: |
+        echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --passphrase "${{ secrets.GPG_SECRET }}" --pinentry-mode loopback --import
 
     - name: Install xmlstartlet and xmllint
       run: |
@@ -98,6 +96,13 @@ jobs:
           echo "Pom file : $F"
           xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]' $F
         done
+
+    - name: Verify dependency signatures (simplify4u pgpverify)
+      run: |
+        cd ${{ inputs.SERVICE_LOCATION }} && mvn org.simplify4u.plugins:pgpverify-maven-plugin:1.19.1:check \
+          -DfailNoSignature=false \
+          -DverifySnapshots=false \
+          -s $GITHUB_WORKSPACE/settings.xml
 
     - name: Build with Maven
       run: cd ${{ inputs.SERVICE_LOCATION }} && mvn -U -B package -Dmaven.wagon.http.retryHandler.count=2 --file pom.xml -s $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish-android.yml
+++ b/.github/workflows/maven-publish-android.yml
@@ -83,10 +83,8 @@ jobs:
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_SECRET }}
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --passphrase "${{ secrets.GPG_SECRET }}" --pinentry-mode loopback --import
 
       - name: Install xmlstartlet and xmllint
         run: |

--- a/.github/workflows/maven-publish-to-nexus.yml
+++ b/.github/workflows/maven-publish-to-nexus.yml
@@ -50,10 +50,8 @@ jobs:
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
 
     - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v6
-      with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_SECRET }}
+      run: |
+        echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --passphrase "${{ secrets.GPG_SECRET }}" --pinentry-mode loopback --import
 
     - name: Setup the settings file for ossrh server
       run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://central.sonatype.com/repository/maven-snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://central.sonatype.com/api/v1/publisher</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/npm-sonar-analysis.yml
+++ b/.github/workflows/npm-sonar-analysis.yml
@@ -130,7 +130,7 @@ jobs:
     - name: run sonar analysis
       run: |
         cd "./${{inputs.SERVICE_LOCATION}}"     
-        npm install sonar-scanner && npm run sonar -- -Dsonar.login=${{ env.SONAR_TOKEN }} -Dsonar.organization=${{ env.ORG_KEY }} ${{ inputs.SONAR_ARGS }}
+        npm install sonar-scanner && npm run sonar -- -Dsonar.token=${{ env.SONAR_TOKEN }} -Dsonar.organization=${{ env.ORG_KEY }} ${{ inputs.SONAR_ARGS }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

- Remove crazy-max/ghaction-import-gpg@v6 dependency from maven-build, maven-publish-to-nexus, and maven-publish-android workflows
- Import GPG private key directly via gpg --batch --import using the same GPG_PRIVATE_KEY and GPG_SECRET secrets; no third-party action needed
- Add simplify4u pgpverify-maven-plugin 1.19.1 check step in maven-build before the build runs; verifies signatures of resolved dependencies (failNoSignature=false, verifySnapshots=false for initial rollout)