### PR TITLE
fix: guard GPG import against empty secret and make pgpverify non-blocking

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -53,8 +53,15 @@ jobs:
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
 
     - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_SECRET: ${{ secrets.GPG_SECRET }}
       run: |
-        echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --passphrase "${{ secrets.GPG_SECRET }}" --pinentry-mode loopback --import
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+        else
+          echo "GPG_PRIVATE_KEY not set, skipping import"
+        fi
 
     - name: Install xmlstartlet and xmllint
       run: |
@@ -98,6 +105,7 @@ jobs:
         done
 
     - name: Verify dependency signatures (simplify4u pgpverify)
+      continue-on-error: true
       run: |
         cd ${{ inputs.SERVICE_LOCATION }} && mvn org.simplify4u.plugins:pgpverify-maven-plugin:1.19.1:check \
           -DfailNoSignature=false \

--- a/.github/workflows/maven-publish-android.yml
+++ b/.github/workflows/maven-publish-android.yml
@@ -83,8 +83,15 @@ jobs:
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
 
       - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --passphrase "${{ secrets.GPG_SECRET }}" --pinentry-mode loopback --import
+          if [ -n "$GPG_PRIVATE_KEY" ]; then
+            echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+          else
+            echo "GPG_PRIVATE_KEY not set, skipping import"
+          fi
 
       - name: Install xmlstartlet and xmllint
         run: |

--- a/.github/workflows/maven-publish-to-nexus.yml
+++ b/.github/workflows/maven-publish-to-nexus.yml
@@ -50,8 +50,15 @@ jobs:
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
 
     - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_SECRET: ${{ secrets.GPG_SECRET }}
       run: |
-        echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --passphrase "${{ secrets.GPG_SECRET }}" --pinentry-mode loopback --import
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+        else
+          echo "GPG_PRIVATE_KEY not set, skipping import"
+        fi
 
     - name: Setup the settings file for ossrh server
       run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://central.sonatype.com/repository/maven-snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://central.sonatype.com/api/v1/publisher</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml


### PR DESCRIPTION


- Wrap gpg --import in a non-empty check so workflows without GPG_PRIVATE_KEY skip import gracefully instead of failing exit code 2
- Add continue-on-error: true to pgpverify step so signature findings are logged without blocking the build during initial rollout