### PR TITLE
ci: migrate GPG key import from committed files to GitHub secret

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -9,6 +9,10 @@ on:
       BUILD_ARTIFACT:
         required: true
         type: string
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -17,6 +21,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: true
@@ -44,18 +50,41 @@ jobs:
 
     - name: Setup branch and env
       run: |
-        # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV  
 
-    - name: Setup branch and GPG public key
+    - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_SECRET: ${{ secrets.GPG_SECRET }}
       run: |
-        # Strip git ref prefix from version
-        echo ${{ env.BRANCH_NAME }}
-        echo ${{ env.GPG_TTY }}
-        sudo apt-get --yes install gnupg2
-        gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-        gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+        else
+          echo "GPG_PRIVATE_KEY not set, skipping import"
+        fi
+
+    - name: Check GPG key age
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
+      run: |
+        if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+        CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+        if [ -z "$CREATED" ]; then exit 0; fi
+        NOW=$(date +%s)
+        AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+        AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+        echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+        if [ $AGE_DAYS -gt 1095 ]; then
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+          else
+            echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+            exit 1
+          fi
+        elif [ $AGE_DAYS -gt 730 ]; then
+          echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+        fi
 
     - name: Install xmlstartlet and xmllint
       run: |
@@ -154,6 +183,14 @@ jobs:
           echo "Pom file : $F"
           xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]' $F
         done
+
+    - name: Verify dependency signatures (simplify4u pgpverify)
+      continue-on-error: true
+      run: |
+        cd ${{ inputs.SERVICE_LOCATION }} && mvn org.simplify4u.plugins:pgpverify-maven-plugin:1.19.1:check \
+          -DfailNoSignature=false \
+          -DverifySnapshots=false \
+          -s $GITHUB_WORKSPACE/settings.xml
 
     - name: Build with Maven
       run: cd ${{ inputs.SERVICE_LOCATION }} && mvn -U -B package -Dmaven.wagon.http.retryHandler.count=2 --file pom.xml -s $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish-android.yml
+++ b/.github/workflows/maven-publish-android.yml
@@ -12,7 +12,6 @@ on:
         required: true
         default: "android"
         type: string
-    inputs:
       FORCE_BUILD:
         required: false
         type: string

--- a/.github/workflows/maven-publish-android.yml
+++ b/.github/workflows/maven-publish-android.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: "android"
         type: string
+    inputs:
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -22,6 +27,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: true
@@ -77,18 +84,41 @@ jobs:
 
       - name: Setup branch and env
         run: |
-          # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
-      - name: Setup branch and GPG public key
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
         run: |
-          # Strip git ref prefix from version
-          echo ${{ env.BRANCH_NAME }}
-          echo ${{ env.GPG_TTY }}
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg
+          if [ -n "$GPG_PRIVATE_KEY" ]; then
+            echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+          else
+            echo "GPG_PRIVATE_KEY not set, skipping import"
+          fi
+
+      - name: Check GPG key age
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+          CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+          if [ -z "$CREATED" ]; then exit 0; fi
+          NOW=$(date +%s)
+          AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+          AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+          echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+          if [ $AGE_DAYS -gt 1095 ]; then
+            if [ "$FORCE_BUILD" = "true" ]; then
+              echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+            else
+              echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+              exit 1
+            fi
+          elif [ $AGE_DAYS -gt 730 ]; then
+            echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+          fi
 
       - name: Install xmlstartlet and xmllint
         run: |

--- a/.github/workflows/maven-publish-to-nexus.yml
+++ b/.github/workflows/maven-publish-to-nexus.yml
@@ -6,7 +6,6 @@ on:
       SERVICE_LOCATION:
         required: true
         type: string
-    inputs:
       FORCE_BUILD:
         required: false
         type: string

--- a/.github/workflows/maven-publish-to-nexus.yml
+++ b/.github/workflows/maven-publish-to-nexus.yml
@@ -6,6 +6,11 @@ on:
       SERVICE_LOCATION:
         required: true
         type: string
+    inputs:
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -16,6 +21,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: false
@@ -44,18 +51,41 @@ jobs:
 
     - name: Setup branch and env
       run: |
-        # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
-    - name: Setup branch and GPG public key
+    - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_SECRET: ${{ secrets.GPG_SECRET }}
       run: |
-        # Strip git ref prefix from version
-        echo ${{ env.BRANCH_NAME }}
-        echo ${{ env.GPG_TTY }}
-        sudo apt-get --yes install gnupg2
-        gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-        gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+        else
+          echo "GPG_PRIVATE_KEY not set, skipping import"
+        fi
+
+    - name: Check GPG key age
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
+      run: |
+        if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+        CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+        if [ -z "$CREATED" ]; then exit 0; fi
+        NOW=$(date +%s)
+        AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+        AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+        echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+        if [ $AGE_DAYS -gt 1095 ]; then
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+          else
+            echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+            exit 1
+          fi
+        elif [ $AGE_DAYS -gt 730 ]; then
+          echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+        fi
 
     - name: Setup the settings file for ossrh server
       run: echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USER}}</username><password>${{secrets.OSSRH_SECRET}}</password></server></servers><profiles><profile><id>ossrh</id><activation><activeByDefault>true</activeByDefault></activation><properties><gpg.executable>gpg2</gpg.executable><gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase></properties></profile><profile><id>allow-snapshots</id><activation><activeByDefault>true</activeByDefault></activation><repositories><repository><id>snapshots-repo</id><url>https://central.sonatype.com/repository/maven-snapshots</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>releases-repo</id><url>https://central.sonatype.com/api/v1/publisher</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository><repository><id>danubetech-maven-public</id><url>https://repo.danubetech.com/repository/maven-public/</url></repository></repositories></profile><profile><id>sonar</id><properties><sonar.sources>.</sonar.sources><sonar.host.url>https://sonarcloud.io</sonar.host.url></properties><activation><activeByDefault>false</activeByDefault></activation></profile></profiles></settings>" > $GITHUB_WORKSPACE/settings.xml
@@ -68,7 +98,6 @@ jobs:
         cd ${{ inputs.SERVICE_LOCATION }} && mvn -DskipTests -U -B deploy -Dmaven.wagon.http.retryHandler.count=2 -DaltDeploymentRepository=ossrh::default::${{ secrets.OSSRH_URL }} -s $GITHUB_WORKSPACE/settings.xml -f pom.xml
       env:
         GITHUB_TOKEN: ${{secrets.OSSRH_TOKEN}}
-        GPG_TTY: $(tty)
 
     # - uses: 8398a7/action-slack@v3
     #   with:

--- a/.github/workflows/maven-sonar-analysis-new.yml
+++ b/.github/workflows/maven-sonar-analysis-new.yml
@@ -52,13 +52,6 @@ jobs:
       - name: Setup env
         run: |
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
-
-      - name: Import GPG
-        run: |
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg
-          gpg2 --quiet --batch --passphrase=${{ secrets.GPG_SECRET }} --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg
 
       - name: Setup Maven settings
         run: |
@@ -71,6 +64,7 @@ jobs:
           FULL_PROJECT_KEY="${{ secrets.ORG_KEY }}_${FINAL_NAME}"
           cd "${{ inputs.SERVICE_LOCATION || '.' }}" && \
           mvn -U -B verify sonar:sonar \
+            -Dgpg.skip=true \
             -Dmaven.wagon.http.retryHandler.count=2 \
             -Dsonar.projectKey=${FULL_PROJECT_KEY} \
             -Dsonar.organization=${{ secrets.ORG_KEY }} \

--- a/.github/workflows/maven-sonar-analysis.yml
+++ b/.github/workflows/maven-sonar-analysis.yml
@@ -53,19 +53,8 @@ jobs:
 
       - name: Setup branch and env
         run: |
-          # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           echo "SONAR URL : ${{ inputs.SONAR_URL }}"
-
-      - name: Setup branch and GPG public key
-        run: |
-          # Strip git ref prefix from version
-          echo ${{ env.BRANCH_NAME }}
-          echo ${{ env.GPG_TTY }}
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
 
       - name: Setup the settings file for ossrh server
         run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://oss.sonatype.org/content/repositories/snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml
@@ -75,7 +64,7 @@ jobs:
 
       - name: Analyze with SonarCloud
         run: |
-          cd ${{ inputs.SERVICE_LOCATION }} &&  mvn -U -B verify sonar:sonar -Dmaven.wagon.http.retryHandler.count=2 -Dsonar.projectKey=${{ inputs.PROJECT_KEY }} -Dsonar.organization=${{ secrets.ORG_KEY }} -Dsonar.host.url=${{ inputs.SONAR_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }} --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
+          cd ${{ inputs.SERVICE_LOCATION }} &&  mvn -U -B verify sonar:sonar -Dgpg.skip=true -Dmaven.wagon.http.retryHandler.count=2 -Dsonar.projectKey=${{ inputs.PROJECT_KEY }} -Dsonar.organization=${{ secrets.ORG_KEY }} -Dsonar.host.url=${{ inputs.SONAR_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }} --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
- Replace file-based gpg2 import with secret-based import via GPG_PRIVATE_KEY
- Add GPG key age check: warn at 2 years, hard stop at 3 years (bypassable with FORCE_BUILD=true)
- Add simplify4u pgpverify step (non-blocking) to audit external dependency signatures
- Remove unnecessary GPG_TTY env setup
- Applied to maven-build.yml, maven-publish-to-nexus.yml, maven-publish-android.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new build option to let release workflows continue even when signing keys are older than expected.
  * Improved package signing checks during builds to better validate dependency signatures.

* **Bug Fixes**
  * Updated release workflows to use supplied signing credentials more reliably.
  * Added clearer warnings and blocking behavior when signing keys are nearing expiration or too old.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->