### PR TITLE
ci: migrate GPG key import to GitHub secret and skip GPG in sonar

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -11,7 +11,11 @@ on:
         type: string
       MAVEN_NON_EXEC_ARTIFACTS:
         required: false
-        type: string 
+        type: string
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -20,6 +24,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: true
@@ -47,18 +53,41 @@ jobs:
 
     - name: Setup branch and env
       run: |
-        # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV  
 
-    - name: Setup branch and GPG public key
+    - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_SECRET: ${{ secrets.GPG_SECRET }}
       run: |
-        # Strip git ref prefix from version
-        echo ${{ env.BRANCH_NAME }}
-        echo ${{ env.GPG_TTY }}
-        sudo apt-get --yes install gnupg2
-        gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-        gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+        else
+          echo "GPG_PRIVATE_KEY not set, skipping import"
+        fi
+
+    - name: Check GPG key age
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
+      run: |
+        if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+        CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+        if [ -z "$CREATED" ]; then exit 0; fi
+        NOW=$(date +%s)
+        AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+        AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+        echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+        if [ $AGE_DAYS -gt 1095 ]; then
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+          else
+            echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+            exit 1
+          fi
+        elif [ $AGE_DAYS -gt 730 ]; then
+          echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+        fi
 
     - name: Install xmlstartlet and xmllint
       run: |
@@ -100,6 +129,14 @@ jobs:
           echo "Pom file : $F"
           xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]' $F
         done
+
+    - name: Verify dependency signatures (simplify4u pgpverify)
+      continue-on-error: true
+      run: |
+        cd ${{ inputs.SERVICE_LOCATION }} && mvn org.simplify4u.plugins:pgpverify-maven-plugin:1.19.1:check \
+          -DfailNoSignature=false \
+          -DverifySnapshots=false \
+          -s $GITHUB_WORKSPACE/settings.xml
 
     - name: Build with Maven
       run: cd ${{ inputs.SERVICE_LOCATION }} && mvn -U -B package -Dmaven.wagon.http.retryHandler.count=2 --file pom.xml -s $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish-android.yml
+++ b/.github/workflows/maven-publish-android.yml
@@ -30,6 +30,10 @@ on:
         description: "Maven group path (e.g. io/mosip or io/inji)"
         required: true
         type: string
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -40,6 +44,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: true
@@ -99,25 +105,46 @@ jobs:
           sudo apt-get update
           sudo apt-get install xmlstarlet libxml2-utils gnupg2 -y
 
-      - name: Setup GPG public key
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
         run: |
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg
+          if [ -n "$GPG_PRIVATE_KEY" ]; then
+            echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+          else
+            echo "GPG_PRIVATE_KEY not set, skipping import"
+          fi
 
-      - name: Setup environmental variable for branch, GPG_TTY, & GPG KEY_ID
+      - name: Setup branch and GPG KEY_ID
         run: |
-          # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | awk -F'/' '{print $2}')
           echo "Extracted KEY_ID=$KEY_ID"
           echo "KEY_ID=$KEY_ID" >> $GITHUB_ENV
 
-      - name: Debug environment variables
+      - name: Check GPG key age
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
         run: |
-          echo "BRANCH_NAME=${{ env.BRANCH_NAME }}"
-          echo "KEY_ID=${{ env.KEY_ID }}"
-          echo "GPG_TTY=${{ env.GPG_TTY }}"
+          if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+          CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+          if [ -z "$CREATED" ]; then exit 0; fi
+          NOW=$(date +%s)
+          AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+          AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+          echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+          if [ $AGE_DAYS -gt 1095 ]; then
+            if [ "$FORCE_BUILD" = "true" ]; then
+              echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+            else
+              echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+              exit 1
+            fi
+          elif [ $AGE_DAYS -gt 730 ]; then
+            echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+          fi
 
       - name: Setup the settings file for ossrh server
         run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://central.sonatype.com/repository/maven-snapshots/</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io/inji</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml

--- a/.github/workflows/maven-publish-to-nexus.yml
+++ b/.github/workflows/maven-publish-to-nexus.yml
@@ -6,6 +6,10 @@ on:
       SERVICE_LOCATION:
         required: true
         type: string
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -16,6 +20,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: false
@@ -44,18 +50,41 @@ jobs:
 
     - name: Setup branch and env
       run: |
-        # Strip git ref prefix from version
         echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-        echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
 
-    - name: Setup branch and GPG public key
+    - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_SECRET: ${{ secrets.GPG_SECRET }}
       run: |
-        # Strip git ref prefix from version
-        echo ${{ env.BRANCH_NAME }}
-        echo ${{ env.GPG_TTY }}
-        sudo apt-get --yes install gnupg2
-        gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-        gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+        else
+          echo "GPG_PRIVATE_KEY not set, skipping import"
+        fi
+
+    - name: Check GPG key age
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
+      run: |
+        if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+        CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+        if [ -z "$CREATED" ]; then exit 0; fi
+        NOW=$(date +%s)
+        AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+        AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+        echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+        if [ $AGE_DAYS -gt 1095 ]; then
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+          else
+            echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+            exit 1
+          fi
+        elif [ $AGE_DAYS -gt 730 ]; then
+          echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+        fi
 
     - name: Setup the settings file for ossrh server
       run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://central.sonatype.com/repository/maven-snapshots/</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://central.sonatype.com/api/v1/publisher</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml
@@ -66,8 +95,6 @@ jobs:
     - name: Publish the maven package
       run: |
         cd ${{ inputs.SERVICE_LOCATION }} && mvn -DskipTests -U -B deploy -Dmaven.wagon.http.retryHandler.count=2 -DaltDeploymentRepository=ossrh::default::${{ secrets.OSSRH_URL }} -s $GITHUB_WORKSPACE/settings.xml -f pom.xml
-      env:
-        GPG_TTY: $(tty)
 
     # - uses: 8398a7/action-slack@v3
     #   with:

--- a/.github/workflows/maven-sonar-analysis.yml
+++ b/.github/workflows/maven-sonar-analysis.yml
@@ -53,19 +53,8 @@ jobs:
 
       - name: Setup branch and env
         run: |
-          # Strip git ref prefix from version
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           echo "SONAR URL : ${{ inputs.SONAR_URL }}"
-
-      - name: Setup branch and GPG public key
-        run: |
-          # Strip git ref prefix from version
-          echo ${{ env.BRANCH_NAME }}
-          echo ${{ env.GPG_TTY }}
-          sudo apt-get --yes install gnupg2
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg 
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}}  --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg 
 
       - name: Setup the settings file for ossrh server
         run: echo "<settings> <servers> <server> <id>ossrh</id> <username>${{secrets.OSSRH_USER}}</username> <password>${{secrets.OSSRH_SECRET}}</password> </server> </servers> <profiles> <profile> <id>ossrh</id> <activation> <activeByDefault>true</activeByDefault> </activation> <properties> <gpg.executable>gpg2</gpg.executable> <gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase> </properties> </profile> <profile> <id>allow-snapshots</id> <activation><activeByDefault>true</activeByDefault></activation> <repositories> <repository> <id>snapshots-repo</id> <url>https://oss.sonatype.org/content/repositories/snapshots</url> <releases><enabled>false</enabled></releases> <snapshots><enabled>true</enabled></snapshots> </repository> <repository> <id>releases-repo</id> <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url> <releases><enabled>true</enabled></releases> <snapshots><enabled>false</enabled></snapshots> </repository> <repository> <id>danubetech-maven-public</id> <url>https://repo.danubetech.com/repository/maven-public/</url> </repository> </repositories> </profile> <profile> <id>sonar</id> <properties> <sonar.sources>.</sonar.sources> <sonar.host.url>https://sonarcloud.io</sonar.host.url> </properties> <activation> <activeByDefault>false</activeByDefault> </activation> </profile> </profiles> </settings>" > $GITHUB_WORKSPACE/settings.xml
@@ -75,7 +64,7 @@ jobs:
 
       - name: Analyze with SonarCloud
         run: |
-          cd ${{ inputs.SERVICE_LOCATION }} &&  mvn -U -B verify sonar:sonar -Dmaven.wagon.http.retryHandler.count=2 -Dsonar.projectKey=${{ inputs.PROJECT_KEY }} -Dsonar.organization=${{ secrets.ORG_KEY }} -Dsonar.host.url=${{ inputs.SONAR_URL }} -Dsonar.login=${{ secrets.SONAR_TOKEN }} --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
+          cd ${{ inputs.SERVICE_LOCATION }} &&  mvn -U -B verify sonar:sonar -Dgpg.skip=true -Dmaven.wagon.http.retryHandler.count=2 -Dsonar.projectKey=${{ inputs.PROJECT_KEY }} -Dsonar.organization=${{ secrets.ORG_KEY }} -Dsonar.host.url=${{ inputs.SONAR_URL }} -Dsonar.login=${{ secrets.SONAR_TOKEN }} --file pom.xml -s $GITHUB_WORKSPACE/settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
- Replace file-based gpg2 import with secret-based import via GPG_PRIVATE_KEY
- Add GPG key age check: warn at 2 years, hard stop at 3 years (bypassable with FORCE_BUILD=true)
- Add simplify4u pgpverify step (non-blocking) in maven-build to audit external dependency signatures
- Preserve KEY_ID extraction for Gradle gnupg signing in android publish
- Remove unnecessary GPG_TTY setup
- Skip GPG in sonar analysis (analysis-only, no publishing) via -Dgpg.skip=true
- Applied to maven-build, maven-publish-to-nexus, maven-publish-android, maven-sonar-analysis