### PR TITLE
ci: migrate GPG key import to GitHub secret in android-download workflow

### DIFF
--- a/.github/workflows/maven-publish-android-download.yaml
+++ b/.github/workflows/maven-publish-android-download.yaml
@@ -35,6 +35,10 @@ on:
         description: "Maven group path (e.g. io/mosip or io/inji)"
         required: true
         type: string
+      FORCE_BUILD:
+        required: false
+        type: string
+        default: 'true'
     secrets:
       OSSRH_USER:
         required: true
@@ -45,6 +49,8 @@ on:
       OSSRH_TOKEN:
         required: true
       GPG_SECRET:
+        required: true
+      GPG_PRIVATE_KEY:
         required: true
       SLACK_WEBHOOK_URL:
         required: true
@@ -105,24 +111,52 @@ jobs:
           sudo apt-get update
           sudo apt-get install xmlstarlet libxml2-utils gnupg2 -y
 
-      - name: Setup GPG public key
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
         run: |
-          gpg2 --import ./.github/keys/mosipgpgkey_pub.gpg
-          gpg2 --quiet --batch --passphrase=${{secrets.GPG_SECRET}} --allow-secret-key-import --import ./.github/keys/mosipgpgkey_sec.gpg
+          if [ -n "$GPG_PRIVATE_KEY" ]; then
+            echo "$GPG_PRIVATE_KEY" | gpg --batch --passphrase "$GPG_SECRET" --pinentry-mode loopback --import
+          else
+            echo "GPG_PRIVATE_KEY not set, skipping import"
+          fi
 
-      - name: Setup environmental variable for branch, GPG_TTY, & GPG KEY_ID
+      - name: Setup branch and GPG KEY_ID
         run: |
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed -e 's,.*/\(.*\),\1,')" >> $GITHUB_ENV
-          echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
           KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | awk -F'/' '{print $2}')
+          echo "Extracted KEY_ID=$KEY_ID"
           echo "KEY_ID=$KEY_ID" >> $GITHUB_ENV
+
+      - name: Check GPG key age
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          FORCE_BUILD: ${{ inputs.FORCE_BUILD }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then exit 0; fi
+          CREATED=$(gpg --list-keys --with-colons 2>/dev/null | awk -F: '/^pub/{print $6; exit}')
+          if [ -z "$CREATED" ]; then exit 0; fi
+          NOW=$(date +%s)
+          AGE_DAYS=$(( (NOW - CREATED) / 86400 ))
+          AGE_YEARS=$(echo "scale=1; $AGE_DAYS / 365" | bc)
+          echo "GPG key age: $AGE_DAYS days (~$AGE_YEARS years)"
+          if [ $AGE_DAYS -gt 1095 ]; then
+            if [ "$FORCE_BUILD" = "true" ]; then
+              echo "::warning::GPG key is over 3 years old ($AGE_YEARS years). FORCE_BUILD=true — KEY ROTATION IS OVERDUE."
+            else
+              echo "::error::GPG key is over 3 years old ($AGE_YEARS years). Rotate the key or set FORCE_BUILD=true to override."
+              exit 1
+            fi
+          elif [ $AGE_DAYS -gt 730 ]; then
+            echo "::warning::GPG key is over 2 years old ($AGE_YEARS years). Schedule key rotation soon."
+          fi
 
       - name: Debug environment variables
         run: |
           echo "GROUP_PATH=${{ inputs.GROUP_PATH }}"
           echo "BRANCH_NAME=${{ env.BRANCH_NAME }}"
           echo "KEY_ID=${{ env.KEY_ID }}"
-          echo "GPG_TTY=${{ env.GPG_TTY }}"
           echo "PUBLICATION_TYPE=${{ inputs.PUBLICATION_TYPE }}"
           echo "RELEASE_TYPE=${{ inputs.RELEASE_TYPE }}"
 


### PR DESCRIPTION
## What

Applies the same GPG-secret migration already used in `maven-publish-android.yml` to `maven-publish-android-download.yaml`, which was still importing the committed key files.

## Changes
- Replace committed-keyfile `gpg2 --import` with secret-based import via `GPG_PRIVATE_KEY`
- Preserve `KEY_ID` extraction for Gradle `signing.gnupg` signing
- Add GPG key age check (warn at 2y, hard stop at 3y, bypassable via `FORCE_BUILD`)
- Add `FORCE_BUILD` input and `GPG_PRIVATE_KEY` secret
- Drop unused `GPG_TTY` setup and its debug echo

## Caller impact
Callers of this reusable workflow must now pass the `GPG_PRIVATE_KEY` secret (as they already do for `maven-publish-android.yml`).

Scope: single file; mirrors the existing android publish workflow on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)