### PR TITLE
correct the command to validate license

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -75,7 +75,9 @@ jobs:
       run: echo "<settings><servers><server><id>ossrh</id><username>${{secrets.OSSRH_USER}}</username><password>${{secrets.OSSRH_SECRET}}</password></server></servers><profiles><profile><id>ossrh</id><activation><activeByDefault>true</activeByDefault></activation><properties><gpg.executable>gpg2</gpg.executable><gpg.passphrase>${{secrets.GPG_SECRET}}</gpg.passphrase></properties></profile><profile><id>allow-snapshots</id><activation><activeByDefault>true</activeByDefault></activation><repositories><repository><id>snapshots-repo</id><url>https://central.sonatype.com/repository/maven-snapshots</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository><repository><id>releases-repo</id><url>https://central.sonatype.com/api/v1/publisher</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots></repository><repository><id>danubetech-maven-public</id><url>https://repo.danubetech.com/repository/maven-public/</url></repository><repository><id>nexus-snapshots</id><url>https://oss.sonatype.org/content/repositories/snapshots</url></repository></repositories></profile><profile><id>sonar</id><properties><sonar.sources>.</sonar.sources><sonar.host.url>https://sonarcloud.io</sonar.host.url></properties><activation><activeByDefault>false</activeByDefault></activation></profile></profiles></settings>" > $GITHUB_WORKSPACE/settings.xml
 
     - name: Build check for MOSIP License
-      run: cd ${{ inputs.SERVICE_LOCATION }} && xmlstarlet sel -N s="http://maven.apache.org/POM/4.0.0" -t -v "//s:project/s:licenses[1]/s:license/s:name" -nl pom.xml | grep -q "${{ inputs.LICENSE_NAME }}"
+      run: |
+        cd ${{ inputs.SERVICE_LOCATION }}
+        xmlstarlet sel -N s="http://maven.apache.org/POM/4.0.0" -t -v "//s:project/s:licenses[1]/s:license/s:name" -nl pom.xml | grep -q "${{ inputs.LICENSE_NAME }}"
 
     - name: Build check for developer
       run: cd ${{ inputs.SERVICE_LOCATION }} && xmlstarlet sel -N s="http://maven.apache.org/POM/4.0.0" -t -v "//s:project/s:developers[1]/s:developer/s:name" -nl pom.xml | grep -icq "Mosip"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted the Maven license verification workflow step without changing its behavior.
  * License checks continue to validate the project’s declared license during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->