### PR TITLE
Fix Sonar analysis by using JDK 21

### DIFF
--- a/.github/workflows/gradlew-sonar-analysis.yml
+++ b/.github/workflows/gradlew-sonar-analysis.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
**Root cause:** gradlew-sonar-analysis.yml did not explicitly configure a JDK, so Sonar analysis ran with the GitHub runner's default Java 17. SonarCloud now requires Java 21+ for analysis.

**Fix:** Added an explicit actions/setup-java step to configure Temurin JDK 21 before running ./gradlew build sonarqube



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code analysis workflow to use Java 21.
  * Enabled Gradle dependency caching during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->