### PR TITLE
fix(sonar): use standalone scanner action instead of Gradle plugin task

### DIFF
--- a/.github/workflows/gradlew-sonar-analysis.yml
+++ b/.github/workflows/gradlew-sonar-analysis.yml
@@ -74,17 +74,25 @@ jobs:
             exit 1;
           fi
 
-      - name: Analysis with Sonarcloud
+      - name: Build (compile only)
         run: |
           cd ${{ inputs.SERVICE_LOCATION }}
           sed -i -e 's/\r$//' ./gradlew
           chmod +x ./gradlew
-          ./gradlew build sonarqube \
-            -Dsonar.organization=${{ secrets.ORG_KEY }} \
-            -Dsonar.projectKey=${{ secrets.ORG_KEY }}_${{ github.event.repository.name }} \
-            -Dsonar.projectName=${{ github.event.repository.name }} \
-            -Dsonar.host.url=${{ inputs.SONAR_URL }} \
-            --info --warning-mode all ${{ inputs.SONAR_ARGS }}
+          ./gradlew build
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        with:
+          projectBaseDir: ${{ inputs.SERVICE_LOCATION }}
+          args: >
+            -Dsonar.organization=${{ secrets.ORG_KEY }}
+            -Dsonar.projectKey=${{ secrets.ORG_KEY }}_${{ github.event.repository.name }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            ${{ inputs.SONAR_ARGS }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.SONAR_URL }}
 
       # As part of a move to centralized CI/CD notifications, we're temporarily disabling per-workflow Slack alerts. This avoids duplicate/inconsistent messages while the new centralized routing is rolled out. Build and deployment behavior is unaffected — only notifications are changing.
       # - uses: 8398a7/action-slack@v3


### PR DESCRIPTION
The Gradle-plugin-based 'sonarqube' task (via org.sonarqube plugin) requires a newer version to run under JDK 21, but newer plugin versions depend on AGP's modern Variant API (com.android.build.api. variant.Component) - which older AGP pins (e.g. tuvali's AGP 4.2.0) don't have. This crashes the sonarqube task with NoClassDefFoundError, even though the actual build compiles fine.

Split into two independent steps:
- plain './gradlew build' (compile only, untouched, unaffected by any Sonar-plugin/AGP coupling)
- SonarSource/sonarqube-scan-action@v4 (standalone scanner CLI, build-tool-agnostic - never touches Gradle internals or AGP)

This satisfies SonarCloud's JDK 21 requirement without needing any AGP/Gradle-wrapper/Kotlin version bump in calling repos.